### PR TITLE
Improvements

### DIFF
--- a/.okta-aws.example
+++ b/.okta-aws.example
@@ -1,4 +1,0 @@
-[default]
-base-url = amplify.okta.com
-store-role = False
-auto-write-profile = True

--- a/.okta-aws.example
+++ b/.okta-aws.example
@@ -1,0 +1,4 @@
+[default]
+base-url = amplify.okta.com
+store-role = False
+auto-write-profile = True

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 role = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
 app = <your_prefered_okta_app> # ex. `Amazon Web Services` to automatically select Amazon Web Services
 session-duration = <seconds> # The duration for the temporary credentials in seconds. Must be between 3600 (1 hour) and 43200 (12 hours) to be valid. If invalid or not specified, session duration defaults to 3600 (1 hour).
+region = <aws-region> # The AWS region to access resources in, e.g. `us-west-2`. Defaults to `us-east-1`.
+
 ```
 
 ## Supported Features

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ username = <your_okta_username>
 password = <your_okta_password> # Only save your password if you know what you are doing!
 factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 role = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
-use-alias-profile = True # Set this to True if you want to use the AWS account alias as the aws profile name. Defaults to False.
+use-alias-profile = True
+# Set the above to True if you want to use the AWS account alias as the aws profile name. Defaults to False.
 app = <your_prefered_okta_app> # ex. `Amazon Web Services` to automatically select Amazon Web Services
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 role = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
 use-alias-profile = True
 # Set the above to True if you want to use the AWS account alias as the aws profile name. Defaults to False.
-app = <your_prefered_okta_app> # ex. `Amazon Web Services` to automatically select Amazon Web Services
+app = <your_prefered_okta_app>
+# ex. `Amazon Web Services` to automatically select Amazon Web Services
 ```
 
 - Initialize the `~/.okta-info.json` file with the following:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If no awscli commands are provided, then okta-awscli will simply output STS cred
 Optional flags:
 - `--profile` Sets your temporary credentials to a profile in `.aws/credentials`. If omitted, credentials will output to console.
 - `--export` Outputs credentials to console instead of writing to ~/.aws/credentials.
-- `--reset` Resets default values in ~/.okta-aws.
+- `--reset` Resets default values in ~/.okta-aws for the okta-profile being used.
 - `--verbose` More verbose output.
 - `--debug` Very verbose output. Useful for debugging.
 - `--cache` Cache the acquired credentials to ~/.okta-credentials.cache (only if --profile is unspecified)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ username = <your_okta_username>
 password = <your_okta_password> # Only save your password if you know what you are doing!
 factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 role = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
+use-alias-profile = True # Set this to True if you want to use the AWS account alias as the aws profile name. Defaults to False.
+app = <your_prefered_okta_app> # ex. `Amazon Web Services` to automatically select Amazon Web Services
+```
+
+- Initialize the `~/.okta-info.json` file with the following:
+
+```
+{}
 ```
 
 ## Supported Features
@@ -45,11 +53,16 @@ role = <your_preferred_okta_role> # AWS role name (match one of the options prom
 
 `okta-awscli --profile <aws_profile> <awscli action> <awscli arguments>`
 - Follow the prompts to enter MFA information (if required) and choose your AWS app and IAM role.
-- Subsequent executions will first check if the STS credentials are still valid and skip Okta authentication if so.
+- The default Okta profile will not store your chosen IAM role, but other profiles will.
 - Multiple Okta profiles are supported, but if none are specified, then `default` will be used.
 
 
-### Example
+### Examples
+
+`okta-awscli --profile cfer-dev`
+
+This command will simply output STS credentials to `cfer-dev` in your credentials file.
+
 
 `okta-awscli --profile my-aws-account iam list-users`
 
@@ -57,7 +70,8 @@ If no awscli commands are provided, then okta-awscli will simply output STS cred
 
 Optional flags:
 - `--profile` Sets your temporary credentials to a profile in `.aws/credentials`. If omitted, credentials will output to console.
-- `--force` Ignores result of STS credentials validation and gets new credentials from AWS. Used in conjunction with `--profile`.
+- `--export` Outputs credentials to console instead of writing to ~/.aws/credentials.
+- `--reset` Resets default values in ~/.okta-aws.
 - `--verbose` More verbose output.
 - `--debug` Very verbose output. Useful for debugging.
 - `--cache` Cache the acquired credentials to ~/.okta-credentials.cache (only if --profile is unspecified)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ username = <your_okta_username>
 factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 role = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
 app = <your_prefered_okta_app> # ex. `Amazon Web Services` to automatically select Amazon Web Services
-session-duration = <seconds> # The duration for the temporary credentials in seconds. Defaults to 3600 (1 hour).
+session-duration = <seconds> # The duration for the temporary credentials in seconds. Must be between 3600 (1 hour) and 43200 (12 hours) to be valid. If invalid or not specified, session duration defaults to 3600 (1 hour).
 ```
 
 ## Supported Features

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ base-url = <your_okta_org>.okta.com
 ## The remaining parameters are optional.
 ## You will be prompted for them, if they're not included here.
 username = <your_okta_username>
-password = <your_okta_password> # Only save your password if you know what you are doing!
 factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 role = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
 use-alias-profile = True

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ session-duration = <seconds> # The duration for the temporary credentials in sec
 
 `okta-awscli --profile <aws_profile> <awscli action> <awscli arguments>`
 - Follow the prompts to enter MFA information (if required) and choose your AWS app and IAM role.
-- The default Okta profile will not store your chosen IAM role, but other profiles will.
 - Multiple Okta profiles are supported, but if none are specified, then `default` will be used.
 
 
@@ -73,6 +72,7 @@ Optional flags:
 - `--profile` Sets your temporary credentials to a profile in `.aws/credentials`. If omitted, credentials will output to console.
 - `--export` Outputs credentials to console instead of writing to ~/.aws/credentials.
 - `--reset` Resets default values in ~/.okta-aws for the okta-profile being used.
+- `--force` Ignores result of STS credentials validation and gets new credentials from AWS. Used in conjunction with `--profile`.
 - `--verbose` More verbose output.
 - `--debug` Very verbose output. Useful for debugging.
 - `--cache` Cache the acquired credentials to ~/.okta-credentials.cache (only if --profile is unspecified)

--- a/README.md
+++ b/README.md
@@ -20,15 +20,21 @@ Parsing the HTML is still required to get the SAML assertion, after authenticati
 [default]
 base-url = <your_okta_org>.okta.com
 
+## These parameters are optional flags to change the default behavior of okta-awscli
+auto-write-profile = True
+# Set the above to "True" if you want to automatically write creds to ~/.aws/credentials. Defaults to False.
+check-valid-creds = False
+# Set the above to "False" if you want new credentials everytime you run okta-awscli. Defaults to True
+store-role = False
+# Set the above to "False" if you want to be prompted for a role everytime you run okta-awscli rather than having the role selected for you. Defaults to True.
+
 ## The remaining parameters are optional.
 ## You will be prompted for them, if they're not included here.
 username = <your_okta_username>
 factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 role = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
-use-alias-profile = True
-# Set the above to True if you want to use the AWS account alias as the aws profile name. Defaults to False.
-app = <your_prefered_okta_app>
-# ex. `Amazon Web Services` to automatically select Amazon Web Services
+app = <your_prefered_okta_app> # ex. `Amazon Web Services` to automatically select Amazon Web Services
+
 ```
 
 ## Supported Features

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ username = <your_okta_username>
 factor = <your_preferred_mfa_factor> # Current choices are: GOOGLE or OKTA
 role = <your_preferred_okta_role> # AWS role name (match one of the options prompted for by "Please select the AWS role" when this parameter is not specified
 app = <your_prefered_okta_app> # ex. `Amazon Web Services` to automatically select Amazon Web Services
-
+session-duration = <seconds> # The duration for the temporary credentials in seconds. Defaults to 3600 (1 hour).
 ```
 
 ## Supported Features

--- a/README.md
+++ b/README.md
@@ -31,12 +31,6 @@ app = <your_prefered_okta_app>
 # ex. `Amazon Web Services` to automatically select Amazon Web Services
 ```
 
-- Initialize the `~/.okta-info.json` file with the following:
-
-```
-{}
-```
-
 ## Supported Features
 
 - Tenant wide MFA support

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -126,7 +126,7 @@ of roles assigned to you.""" % self.role)
 
     def write_sts_token(self, profile, access_key_id, secret_access_key, session_token):
         """ Writes STS auth information to credentials file """
-        region = 'us-east-1
+        region = 'us-east-1'
         output = 'json'
         if not os.path.exists(self.creds_dir):
             os.makedirs(self.creds_dir)

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -23,6 +23,10 @@ class AwsAuth():
         self.logger = logger
         self.role = ""
 
+        okta_info = home_dir + '/.okta-info.json'
+        if not os.path.isfile(okta_info):
+            open(okta_info, 'a').close()
+
         okta_config = home_dir + '/.okta-aws'
         parser = RawConfigParser()
         parser.read(okta_config)
@@ -122,7 +126,10 @@ of roles assigned to you.""" % self.role)
         """ Gets role info from okta-info.json """
         info_file_path = os.path.expanduser('~') + "/.okta-info.json"
         info_file = open(info_file_path, 'r')
-        okta_info = json.loads(info_file.read())
+        okta_info = info_file.read()
+        print(okta_info)
+        print(type(okta_info))
+        okta_info = {} if okta_info is "" else json.loads(okta_info)
         info_file.close()
 
         role_info = []

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -68,7 +68,7 @@ of roles assigned to you.""" % self.role)
                 role_choice = None
 
     @staticmethod
-    def get_sts_token(role_arn, principal_arn, assertion):
+    def get_sts_token(role_arn, principal_arn, assertion, duration):
         """ Gets a token from AWS STS """
 
         # Connect to the GovCloud STS endpoint if a GovCloud ARN is found.
@@ -80,7 +80,8 @@ of roles assigned to you.""" % self.role)
 
         response = sts.assume_role_with_saml(RoleArn=role_arn,
                                              PrincipalArn=principal_arn,
-                                             SAMLAssertion=assertion)
+                                             SAMLAssertion=assertion,
+                                             DurationSeconds=duration)
         credentials = response['Credentials']
         return credentials
 

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -16,18 +16,18 @@ class AwsAuth():
 
     def __init__(self, profile, okta_profile, verbose, logger, reset):
         home_dir = os.path.expanduser('~')
-        self.creds_dir = home_dir + "/.aws"
-        self.creds_file = self.creds_dir + "/credentials"
+        self.creds_dir = os.path.join(home_dir, ".aws")
+        self.creds_file = os.path.join(self.creds_dir, "credentials")
         self.profile = profile
         self.verbose = verbose
         self.logger = logger
         self.role = ""
 
-        okta_info = home_dir + '/.okta-alias-info'
+        okta_info = os.path.join(home_dir, '.okta-alias-info')
         if not os.path.isfile(okta_info):
             open(okta_info, 'a').close()
 
-        okta_config = home_dir + '/.okta-aws'
+        okta_config = os.path.join(home_dir, '.okta-aws')
         parser = RawConfigParser()
         parser.read(okta_config)
 

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -126,7 +126,7 @@ of roles assigned to you.""" % self.role)
 
     def write_sts_token(self, profile, access_key_id, secret_access_key, session_token):
         """ Writes STS auth information to credentials file """
-        region = 'us-east-1'
+        region = 'us-east-1
         output = 'json'
         if not os.path.exists(self.creds_dir):
             os.makedirs(self.creds_dir)
@@ -143,6 +143,7 @@ of roles assigned to you.""" % self.role)
         config.set(profile, 'aws_access_key_id', access_key_id)
         config.set(profile, 'aws_secret_access_key', secret_access_key)
         config.set(profile, 'aws_session_token', session_token)
+        config.set(profile, 'aws_security_token', session_token)
 
         with open(self.creds_file, 'w+') as configfile:
             config.write(configfile)

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -55,7 +55,7 @@ of roles assigned to you.""" % self.role)
                     print(option)
 
                 role_choice = int(input('Please select the AWS role: ')) - 1
-                return roles[role_choice]
+                return role_info[role_choice]
             except ValueError as ex:
                 print("\nYou have selected an invalid role index, please try again.\n")
                 role_choice = None
@@ -225,7 +225,7 @@ of roles assigned to you.""" % self.role)
     def __create_options_from(roles):
         options = []
         for index, role in enumerate(roles):
-            options.append("[%s]: %s : %s" % (str(index + 1).ljust(2), role[2].ljust(27), role[1]))
+            options.append("[%s]: %s : %s" % (str(index + 1).ljust(2), role[2].ljust(27), role[0]))
         return options
 
     def __find_predefined_role_from(self, roles):

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -166,7 +166,10 @@ of roles assigned to you.""" % self.role)
         info_file_path = os.path.expanduser('~') + "/.okta-alias-info"
         info_file = open(info_file_path, 'r')
         okta_info = info_file.read()
-        okta_info = {} if okta_info is "" else json.loads(okta_info)
+        if okta_info == "":
+            okta_info = {}
+        else:
+            okta_info = json.loads(okta_info)
         info_file.close()
 
         role_info = []

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -1,7 +1,9 @@
 """ AWS authentication """
 # pylint: disable=C0325
 import os
+import json
 import base64
+from datetime import date
 import xml.etree.ElementTree as ET
 from collections import namedtuple
 from configparser import RawConfigParser
@@ -29,13 +31,14 @@ class AwsAuth():
             self.role = parser.get(okta_profile, 'role')
             self.logger.debug("Setting AWS role to %s" % self.role)
 
-
     def choose_aws_role(self, assertion):
         """ Choose AWS role from SAML assertion """
 
         roles = self.__extract_available_roles_from(assertion)
+        role_info = self.__get_role_info(roles, assertion)
+
         if self.role:
-            predefined_role = self.__find_predefiend_role_from(roles)
+            predefined_role = self.__find_predefined_role_from(roles)
             if predefined_role:
                 self.logger.info("Using predefined role: %s" % self.role)
                 return predefined_role
@@ -44,12 +47,21 @@ class AwsAuth():
 of roles assigned to you.""" % self.role)
                 self.logger.info("Please choose a role.")
 
-        role_options = self.__create_options_from(roles)
-        for option in role_options:
-            print(option)
+        role_options = self.__create_options_from(role_info)
+        role_choice = None
+        while role_choice is None:
+            try:
+                for option in role_options:
+                    print(option)
 
-        role_choice = int(input('Please select the AWS role: ')) - 1
-        return roles[role_choice]
+                role_choice = int(input('Please select the AWS role: ')) - 1
+                return roles[role_choice]
+            except ValueError as ex:
+                print("\nYou have selected an invalid role index, please try again.\n")
+                role_choice = None
+            except IndexError as ex:
+                print("\nYou have selected an invalid role index, please try again.\n")
+                role_choice = None
 
     @staticmethod
     def get_sts_token(role_arn, principal_arn, assertion):
@@ -99,6 +111,7 @@ of roles assigned to you.""" % self.role)
                 self.logger.info("Temporary credentials have expired. Requesting new credentials.")
                 return False
 
+        print("AWS credentials are still valid.")
         self.logger.info("STS credentials are valid. Nothing to do.")
         return True
 
@@ -124,7 +137,7 @@ of roles assigned to you.""" % self.role)
 
         with open(self.creds_file, 'w+') as configfile:
             config.write(configfile)
-        self.logger.info("Temporary credentials written to profile: %s" % profile)
+        print("Temporary credentials written to profile: %s" % profile)
         self.logger.info("Invoke using: aws --profile %s <service> <command>" % profile)
 
     @staticmethod
@@ -140,14 +153,82 @@ of roles assigned to you.""" % self.role)
                     roles.append(role_tuple(*saml2attributevalue.text.split(',')))
         return roles
 
+    def __get_role_info(self, roles, assertion):
+        """ Gets role info from okta-info.json """
+        info_file_path = os.path.expanduser('~') + "/.okta-info.json"
+        info_file = open(info_file_path, 'r')
+        okta_info = json.loads(info_file.read())
+        info_file.close()
+
+        role_info = []
+        new_okta_info = {}
+        for role in roles:
+            # read the role info from ~/.okta-info.json
+            role_updated = okta_info.get(role, {})
+            alias = role_updated.get('alias')
+
+            last_updated = role_updated.get('last_updated', date.min)
+            current_date = date.today()
+            alias_age = current_date - last_updated
+            if alias_age.days >= 7 or alias is None:
+                self.logger.info("Refreshing cached alias for role %s" % role.role_arn)
+                alias = self.__get_account_alias(role.role_arn, role.principal_arn, assertion)
+                last_updated = current_date
+
+            role_info.append(
+                (role.role_arn, role.principal_arn, alias)
+            )
+            new_okta_info[role.role_arn] = {
+                'last_updated': last_updated,
+                'alias': alias
+            }
+
+        info_file = open(info_file_path, 'w')
+        info_file.write(
+            json.dumps(new_okta_info,
+                sort_keys=True,
+                indent=4,
+                separators=(',', ': '),
+                default=str
+            )
+        )
+        info_file.close()
+        role_info = sorted(role_info, key=lambda role: role[2])
+
+        return role_info
+
+    def __get_account_alias(self, role_arn, principal_arn, assertion):
+        """ Gets  account alias for given role """
+        sts = boto3.client('sts')
+        saml_resp = sts.assume_role_with_saml(
+            RoleArn=role_arn,
+            PrincipalArn=principal_arn,
+            SAMLAssertion=assertion
+        )
+        iam = boto3.client(
+            'iam',
+            aws_access_key_id=saml_resp['Credentials']['AccessKeyId'],
+            aws_secret_access_key=saml_resp['Credentials']['SecretAccessKey'],
+            aws_session_token=saml_resp['Credentials']['SessionToken']
+        )
+
+        try:
+            alias_resp = iam.list_account_aliases()
+            return alias_resp['AccountAliases'][0]
+        except ClientError as ex:
+            if ex.response['Error']['Code'] == 'AccessDenied':
+                self.logger.info(
+                    'Role %s not authorized to perform `list_account_aliases`.' % role_arn)
+            return "unknown"
+
     @staticmethod
     def __create_options_from(roles):
         options = []
         for index, role in enumerate(roles):
-            options.append("%d: %s" % (index + 1, role.role_arn))
+            options.append("[%s]: %s : %s" % (str(index + 1).ljust(2), role[2].ljust(27), role[1]))
         return options
 
-    def __find_predefiend_role_from(self, roles):
+    def __find_predefined_role_from(self, roles):
         found_roles = filter(lambda role_tuple: role_tuple.role_arn == self.role, roles)
         if not found_roles:
             return None

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -3,7 +3,7 @@
 import os
 import json
 import base64
-from datetime import date
+from datetime import datetime, date
 import xml.etree.ElementTree as ET
 from collections import namedtuple
 from configparser import RawConfigParser
@@ -129,10 +129,11 @@ of roles assigned to you.""" % self.role)
         new_okta_info = {}
         for role in roles:
             # read the role info from ~/.okta-info.json
-            role_updated = okta_info.get(role, {})
+            role_updated = okta_info.get(role.role_arn, {})
             alias = role_updated.get('alias')
 
-            last_updated = role_updated.get('last_updated', date.min)
+            last_updated = role_updated.get('last_updated', "0001-01-01")
+            last_updated = datetime.strptime(last_updated, '%Y-%m-%d').date()
             current_date = date.today()
             alias_age = current_date - last_updated
             if alias_age.days >= 7 or alias is None:
@@ -140,6 +141,7 @@ of roles assigned to you.""" % self.role)
                 alias = self.__get_account_alias(role.role_arn, role.principal_arn, assertion)
                 last_updated = current_date
 
+            self.logger.info("Using cached alias for role %s" % role.role_arn)
             role_info.append(
                 (role.role_arn, role.principal_arn, alias)
             )

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -200,7 +200,12 @@ class OktaAuth():
         session_file = open(session_path, 'r')
         session_info = session_file.read()
         session_file.close()
-        session_info = {} if session_info is "" else json.loads(session_info)
+        print("" == session_info)
+        if session_info == "":
+             session_info = {}
+        else:
+            session_info = json.loads(session_info)
+        print(session_info)
 
         expiration_date = datetime.min
         if session_info.get('expiration_date'):

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -11,18 +11,23 @@ try:
 except NameError:
     pass
 
+
 class OktaAuth():
     """ Handles auth to Okta and returns SAML assertion """
-    def __init__(self, okta_profile, verbose, logger, totp_token, okta_auth_config):
+    def __init__(self, okta_profile, verbose, logger,
+                 totp_token, okta_auth_config):
         self.okta_profile = okta_profile
         self.totp_token = totp_token
         self.logger = logger
         self.factor = ""
         self.verbose = verbose
+        self.okta_auth_config = okta_auth_config
         self.https_base_url = "https://%s" % okta_auth_config.base_url_for(okta_profile)
         self.username = okta_auth_config.username_for(okta_profile)
         self.password = okta_auth_config.password_for(okta_profile)
         self.factor = okta_auth_config.factor_for(okta_profile)
+        self.app = okta_auth_config.app_for(okta_profile)
+
 
     def primary_auth(self):
         """ Performs primary auth against Okta """
@@ -58,8 +63,7 @@ class OktaAuth():
             if factor['factorType'] in supported_factor_types:
                 supported_factors.append(factor)
             else:
-                self.logger.info("Unsupported factorType: %s" %
-                                 (factor['factorType'],))
+                self.logger.info("Unsupported factorType: %s" % (factor['factorType'],))
 
         supported_factors = sorted(supported_factors,
                                    key=lambda factor: (
@@ -94,7 +98,8 @@ class OktaAuth():
                 else:
                     print("%d: %s" % (index + 1, factor_name))
             if not self.factor:
-                factor_choice = input('Please select the MFA factor: ') - 1
+                factor_choice = int(input('Please select the MFA factor: ')) - 1
+                self.okta_auth_config.save_chosen_factor_for_profile(self.okta_profile, supported_factors[factor_choice]['provider'])
             self.logger.info("Performing secondary authentication using: %s" %
                              supported_factors[factor_choice]['provider'])
             session_token = self.verify_single_factor(supported_factors[factor_choice],
@@ -172,12 +177,15 @@ class OktaAuth():
             sys.exit(1)
 
         aws_apps = sorted(aws_apps, key=lambda app: app['sortOrder'])
-        print("Available apps:")
+        app_choice = None
         for index, app in enumerate(aws_apps):
-            app_name = app['label']
-            print("%d: %s" % (index + 1, app_name))
+            if self.app and app['label'] == self.app:
+                app_choice = index
+                break
+            print("%d: %s" % (index + 1, app['label']))
+        if app_choice is None:
+            app_choice = int(input('Please select AWS app: ')) - 1
 
-        app_choice = int(input('Please select AWS app: ')) - 1
         return aws_apps[app_choice]['label'], aws_apps[app_choice]['linkUrl']
 
     def get_saml_assertion(self, html):

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -31,7 +31,7 @@ class OktaAuth():
         self.factor = okta_auth_config.factor_for(okta_profile)
         self.app = okta_auth_config.app_for(okta_profile)
 
-        okta_info = os.path.expanduser('~') + '/.okta-token'
+        okta_info = os.path.join(os.path.expanduser('~'), '.okta-token')
         if not os.path.isfile(okta_info):
             open(okta_info, 'a').close()
 
@@ -180,7 +180,7 @@ class OktaAuth():
             'session_id': session_id,
             'expiration_date': expiration_date
         }
-        session_path = os.path.expanduser('~') + "/.okta-token"
+        session_path = os.path.join(os.path.expanduser('~'), ".okta-token")
         self.logger.info("Cacheing Okta session id to ~/.okta-token")
         session_file = open(session_path, 'w')
         session_file.write(
@@ -196,16 +196,14 @@ class OktaAuth():
 
     def get_cached_session_id(self):
         """ Gets Okta session id from ~/.okta-token if valid """
-        session_path = os.path.expanduser('~') + "/.okta-token"
+        session_path = os.path.join(os.path.expanduser('~'), ".okta-token")
         session_file = open(session_path, 'r')
         session_info = session_file.read()
         session_file.close()
-        print("" == session_info)
         if session_info == "":
              session_info = {}
         else:
             session_info = json.loads(session_info)
-        print(session_info)
 
         expiration_date = datetime.min
         if session_info.get('expiration_date'):

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -185,6 +185,10 @@ class OktaAuth():
             print("%d: %s" % (index + 1, app['label']))
         if app_choice is None:
             app_choice = int(input('Please select AWS app: ')) - 1
+            self.okta_auth_config.save_chosen_app_for_profile(
+                self.okta_profile,
+                aws_apps[app_choice]['label']
+            )
 
         return aws_apps[app_choice]['label'], aws_apps[app_choice]['linkUrl']
 

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -65,6 +65,14 @@ class OktaAuthConfig():
             return app
         return None
 
+    def region_for(self, okta_profile):
+        """ Gets region from config """
+        if self._value.has_option(okta_profile, 'region'):
+            region = self._value.get(okta_profile, 'region')
+            self.logger.debug("Setting region to %s" % region)
+            return region
+        return 'us-east-1'
+
     def get_check_valid_creds(self, okta_profile):
         """ Gets if should check if AWS creds are valid from config """
         check_valid_creds = "True"

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -92,6 +92,15 @@ class OktaAuthConfig():
         self.logger.info("Should write profile to ~/.aws/credentials: %s" % auto_write_profile)
         return auto_write_profile
 
+    def get_session_duration(self, okta_profile):
+        """ Gets STS session duration from config as an int"""
+        session_duration = 3600 # AWS docs say default duration is 1 hour (3600 seconds)
+        if self._value.has_option(okta_profile, 'session-duration'):
+            session_duration = self._value.get(okta_profile, 'session-duration')
+
+        self.logger.info("Configured session duration: %s seconds" % session_duration)
+        return int(session_duration)
+
     def save_chosen_role_for_profile(self, okta_profile, role_arn):
         """ Saves role to config """
         if not self._value.has_section(okta_profile):

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -63,8 +63,18 @@ class OktaAuthConfig():
             return app
         return None
 
+    def get_profile_alias(self, okta_profile):
+        """ Gets if should use alias as profile from config """
+        use_alias_as_profile = "False"
+        if self._value.has_option(okta_profile, 'use-alias-profile'):
+            use_alias_as_profile = self._value.get(okta_profile, 'use-alias-profile')
+        else:
+            use_alias_as_profile = self._value.get('default', 'use-alias-profile')
+        self.logger.info("Use alias as profile: %s" % use_alias_as_profile)
+        return use_alias_as_profile
+
     def save_chosen_role_for_profile(self, okta_profile, role_arn):
-        """ Gets role from config """
+        """ Saves role to config """
         if not self._value.has_section(okta_profile):
             self._value.add_section(okta_profile)
 

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -10,6 +10,7 @@ try:
 except NameError:
     pass
 
+
 class OktaAuthConfig():
     """ Config helper class """
     def __init__(self, logger):
@@ -53,6 +54,14 @@ class OktaAuthConfig():
             return factor
         return None
 
+    def app_for(self, okta_profile):
+        """ Gets app from config """
+        if self._value.has_option(okta_profile, 'app'):
+            app = self._value.get(okta_profile, 'app')
+            self.logger.debug("Setting app to %s" % app)
+            return app
+        return None
+
     def save_chosen_role_for_profile(self, okta_profile, role_arn):
         """ Gets role from config """
         if not self._value.has_section(okta_profile):
@@ -60,7 +69,18 @@ class OktaAuthConfig():
 
         base_url = self.base_url_for(okta_profile)
         self._value.set(okta_profile, 'base-url', base_url)
-        self._value.set(okta_profile, 'role', role_arn)
+        if okta_profile != "default":
+            self._value.set(okta_profile, 'role', role_arn)
+
+        with open(self.config_path, 'w+') as configfile:
+            self._value.write(configfile)
+
+    def save_chosen_factor_for_profile(self, okta_profile, factor):
+        """ Saves factor to config """
+        if not self._value.has_section(okta_profile):
+            self._value.add_section(okta_profile)
+
+        self._value.set(okta_profile, 'factor', factor)
 
         with open(self.config_path, 'w+') as configfile:
             self._value.write(configfile)

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -63,14 +63,32 @@ class OktaAuthConfig():
             return app
         return None
 
-    def get_profile_alias(self, okta_profile):
-        """ Gets if should use alias as profile from config """
-        use_alias_as_profile = "False"
-        if self._value.has_option(okta_profile, 'use-alias-profile'):
-            use_alias_as_profile = self._value.get(okta_profile, 'use-alias-profile')
+    def get_check_valid_creds(self, okta_profile):
+        """ Gets if should check if AWS creds are valid from config """
+        check_valid_creds = "True"
+        if self._value.has_option(okta_profile, 'check-valid-creds'):
+            check_valid_creds = self._value.get(okta_profile, 'check-valid-creds')
 
-        self.logger.info("Use alias as profile: %s" % use_alias_as_profile)
-        return use_alias_as_profile
+        self.logger.info("Check if credentials are valid: %s" % check_valid_creds)
+        return check_valid_creds
+
+    def get_store_role(self, okta_profile):
+        """ Gets if should store role to okta-profile from config """
+        store_role = "True"
+        if self._value.has_option(okta_profile, 'store-role'):
+            store_role = self._value.get(okta_profile, 'store-role')
+
+        self.logger.info("Should store role: %s" % store_role)
+        return store_role
+
+    def get_auto_write_profile(self, okta_profile):
+        """ Gets if should auto write aws creds to ~/.aws/credentials from config """
+        auto_write_profile = "False"
+        if self._value.has_option(okta_profile, 'auto-write-profile'):
+            auto_write_profile = self._value.get(okta_profile, 'auto-write-profile')
+
+        self.logger.info("Should write profile to ~/.aws/credentials: %s" % auto_write_profile)
+        return auto_write_profile
 
     def save_chosen_role_for_profile(self, okta_profile, role_arn):
         """ Saves role to config """
@@ -79,8 +97,7 @@ class OktaAuthConfig():
 
         base_url = self.base_url_for(okta_profile)
         self._value.set(okta_profile, 'base-url', base_url)
-        if okta_profile != "default":
-            self._value.set(okta_profile, 'role', role_arn)
+        self._value.set(okta_profile, 'role', role_arn)
 
         with open(self.config_path, 'w+') as configfile:
             self._value.write(configfile)

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -13,8 +13,9 @@ except NameError:
 
 class OktaAuthConfig():
     """ Config helper class """
-    def __init__(self, logger):
+    def __init__(self, logger, reset):
         self.logger = logger
+        self.reset = reset
         self.config_path = os.path.expanduser('~') + '/.okta-aws'
         self._value = RawConfigParser()
         self._value.read(self.config_path)
@@ -31,7 +32,7 @@ class OktaAuthConfig():
 
     def username_for(self, okta_profile):
         """ Gets username from config """
-        if self._value.has_option(okta_profile, 'username'):
+        if self._value.has_option(okta_profile, 'username') and not self.reset:
             username = self._value.get(okta_profile, 'username')
             self.logger.info("Authenticating as: %s" % username)
         else:
@@ -48,7 +49,7 @@ class OktaAuthConfig():
 
     def factor_for(self, okta_profile):
         """ Gets factor from config """
-        if self._value.has_option(okta_profile, 'factor'):
+        if self._value.has_option(okta_profile, 'factor') and not self.reset:
             factor = self._value.get(okta_profile, 'factor')
             self.logger.debug("Setting MFA factor to %s" % factor)
             return factor
@@ -56,7 +57,7 @@ class OktaAuthConfig():
 
     def app_for(self, okta_profile):
         """ Gets app from config """
-        if self._value.has_option(okta_profile, 'app'):
+        if self._value.has_option(okta_profile, 'app') and not self.reset:
             app = self._value.get(okta_profile, 'app')
             self.logger.debug("Setting app to %s" % app)
             return app
@@ -81,6 +82,16 @@ class OktaAuthConfig():
             self._value.add_section(okta_profile)
 
         self._value.set(okta_profile, 'factor', factor)
+
+        with open(self.config_path, 'w+') as configfile:
+            self._value.write(configfile)
+
+    def save_chosen_app_for_profile(self, okta_profile, app):
+        """ Saves app to config """
+        if not self._value.has_section(okta_profile):
+            self._value.add_section(okta_profile)
+
+        self._value.set(okta_profile, 'app', app)
 
         with open(self.config_path, 'w+') as configfile:
             self._value.write(configfile)

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -96,10 +96,14 @@ class OktaAuthConfig():
         """ Gets STS session duration from config as an int"""
         session_duration = 3600 # AWS docs say default duration is 1 hour (3600 seconds)
         if self._value.has_option(okta_profile, 'session-duration'):
-            session_duration = self._value.get(okta_profile, 'session-duration')
+            session_duration = int(self._value.get(okta_profile, 'session-duration'))
+
+        if session_duration > 43200 or session_duration < 3600:
+            self.logger.info("Invalid session duration specified, defaulting to 1 hour.")
+            session_duration = 3600
 
         self.logger.info("Configured session duration: %s seconds" % session_duration)
-        return int(session_duration)
+        return session_duration
 
     def save_chosen_role_for_profile(self, okta_profile, role_arn):
         """ Saves role to config """

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -68,8 +68,7 @@ class OktaAuthConfig():
         use_alias_as_profile = "False"
         if self._value.has_option(okta_profile, 'use-alias-profile'):
             use_alias_as_profile = self._value.get(okta_profile, 'use-alias-profile')
-        else:
-            use_alias_as_profile = self._value.get('default', 'use-alias-profile')
+
         self.logger.info("Use alias as profile: %s" % use_alias_as_profile)
         return use_alias_as_profile
 

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -3,7 +3,7 @@
 import os
 
 from configparser import RawConfigParser
-from getpass import getpass
+from getpass import getpass, getuser
 
 try:
     input = raw_input
@@ -36,7 +36,9 @@ class OktaAuthConfig():
             username = self._value.get(okta_profile, 'username')
             self.logger.info("Authenticating as: %s" % username)
         else:
-            username = input('Enter username: ')
+            username = getuser()
+            entered_username = input('Enter username [%s]: ' % username)
+            username = username if entered_username == "" else entered_username
         return username
 
     def password_for(self, okta_profile):

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -52,6 +52,11 @@ def get_credentials(okta_profile, profile, verbose, logger,
         logger.info("Export flag not set, will write credentials to ~/.aws/credentials.")
         aws_auth.write_sts_token(profile_name, access_key_id,
                                  secret_access_key, session_token)
+        usage_msg = "".join([
+            "\nTo start using these temporary credentials, run:\n",
+            "\n export AWS_PROFILE=%s\n" % profile_name
+        ])
+        print(usage_msg)
 
 
 def console_output(access_key_id, secret_access_key, session_token, verbose):

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -72,7 +72,8 @@ def console_output(access_key_id, secret_access_key, session_token, verbose):
     exports = "\n".join([
         "export AWS_ACCESS_KEY_ID=%s" % access_key_id,
         "export AWS_SECRET_ACCESS_KEY=%s" % secret_access_key,
-        "export AWS_SESSION_TOKEN=%s" % session_token
+        "export AWS_SESSION_TOKEN=%s" % session_token,
+        "export AWS_SECURITY_TOKEN=%s" % session_token
     ])
     print(exports)
 

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -11,14 +11,17 @@ from oktaawscli.aws_auth import AwsAuth
 
 
 def get_credentials(okta_profile, profile, verbose, logger,
-                    totp_token, cache, export, reset):
+                    totp_token, cache, export, reset, force):
     """ Gets credentials from Okta """
     okta_auth_config = OktaAuthConfig(logger, reset)
     aws_auth = AwsAuth(profile, okta_profile, verbose, logger, reset)
+
+    check_creds = okta_auth_config.get_check_valid_creds(okta_profile)
+    if not force and check_creds and aws_auth.check_sts_token(profile):
+        exit(0)
+
     okta = OktaAuth(okta_profile, verbose, logger,
                     totp_token, okta_auth_config)
-
-    # @TODO if should get credentials, get credentials - otherwise return
 
     _, assertion = okta.get_assertion()
     role = aws_auth.choose_aws_role(assertion)
@@ -119,7 +122,7 @@ def main(okta_profile, profile, verbose, version,
         okta_profile = "default"
 
     get_credentials(
-        okta_profile, profile, verbose, logger, token, cache, export, reset
+        okta_profile, profile, verbose, logger, token, cache, export, reset, force
     )
 
     if awscli_args:

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -15,13 +15,15 @@ def get_credentials(aws_auth, okta_profile, profile,
     """ Gets credentials from Okta """
     okta_auth_config = OktaAuthConfig(logger, reset)
     use_alias = okta_auth_config.get_profile_alias(okta_profile)
+    print(use_alias)
+    print(type(use_alias))
 
     okta = OktaAuth(okta_profile, verbose, logger, totp_token, okta_auth_config)
 
     _, assertion = okta.get_assertion()
     role = aws_auth.choose_aws_role(assertion)
     role_arn, principal_arn, alias = role
-    if use_alias:
+    if use_alias == "True":
         profile = alias
 
     okta_auth_config.save_chosen_role_for_profile(okta_profile, role_arn)

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -16,7 +16,6 @@ def get_credentials(okta_profile, profile, verbose, logger,
     okta_auth_config = OktaAuthConfig(logger, reset)
 
     region = okta_auth_config.region_for(okta_profile)
-    print(region)
     aws_auth = AwsAuth(profile, okta_profile, verbose, logger, region, reset)
 
     check_creds = okta_auth_config.get_check_valid_creds(okta_profile)

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -34,10 +34,12 @@ def get_credentials(okta_profile, profile, verbose, logger,
     if store_role == "True":
         okta_auth_config.save_chosen_role_for_profile(okta_profile, role_arn)
 
-    sts_token = aws_auth.get_sts_token(role_arn, principal_arn, assertion)
+    duration = okta_auth_config.get_session_duration(okta_profile)
+    sts_token = aws_auth.get_sts_token(role_arn, principal_arn, assertion, duration)
     access_key_id = sts_token['AccessKeyId']
     secret_access_key = sts_token['SecretAccessKey']
     session_token = sts_token['SessionToken']
+    print("Credentials valid for %s hours" % round(duration/3600,1))
     if profile_name is None or export:
         logger.info("Either profile name not given or export flag set, will output to console.")
         exports = console_output(access_key_id, secret_access_key,

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -14,7 +14,10 @@ def get_credentials(okta_profile, profile, verbose, logger,
                     totp_token, cache, export, reset, force):
     """ Gets credentials from Okta """
     okta_auth_config = OktaAuthConfig(logger, reset)
-    aws_auth = AwsAuth(profile, okta_profile, verbose, logger, reset)
+
+    region = okta_auth_config.region_for(okta_profile)
+    print(region)
+    aws_auth = AwsAuth(profile, okta_profile, verbose, logger, region, reset)
 
     check_creds = okta_auth_config.get_check_valid_creds(okta_profile)
     if not force and check_creds and aws_auth.check_sts_token(profile):

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -15,9 +15,6 @@ def get_credentials(aws_auth, okta_profile, profile,
     """ Gets credentials from Okta """
     okta_auth_config = OktaAuthConfig(logger, reset)
     use_alias = okta_auth_config.get_profile_alias(okta_profile)
-    print(use_alias)
-    print(type(use_alias))
-
     okta = OktaAuth(okta_profile, verbose, logger, totp_token, okta_auth_config)
 
     _, assertion = okta.get_assertion()
@@ -70,7 +67,7 @@ def console_output(access_key_id, secret_access_key, session_token, verbose):
 @click.option('-d', '--debug', is_flag=True, help='Enables debug mode')
 @click.option('-r', '--reset', is_flag=True, help='Resets default values in ~/.okta-aws')
 @click.option('-e', '--export', is_flag=True, help='Outputs credentials to console instead \
-of writing to ~/.aws/credentials.')
+of writing to ~/.aws/credentials')
 @click.option('--okta-profile', help="Name of the profile to use in .okta-aws. \
 If none is provided, then the default profile will be used.\n")
 @click.option('--profile', help="Name of the profile to store temporary \

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -65,8 +65,6 @@ def console_output(access_key_id, secret_access_key, session_token, verbose):
               help='Outputs version number and exits')
 @click.option('-d', '--debug', is_flag=True, help='Enables debug mode')
 @click.option('-r', '--reset', is_flag=True, help='Resets default values in ~/.okta-aws')
-@click.option('-f', '--force', is_flag=True, help='Forces new STS credentials. \
-Skips STS credentials validation.')
 @click.option('--okta-profile', help="Name of the profile to use in .okta-aws. \
 If none is provided, then the default profile will be used.\n")
 @click.option('--profile', help="Name of the profile to store temporary \
@@ -77,7 +75,7 @@ to ~/.okta-credentials.cache\n')
 @click.option('-t', '--token', help='TOTP token from your authenticator app')
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
 def main(okta_profile, profile, verbose, version,
-         debug, force, cache, awscli_args, token, reset):
+         debug, cache, awscli_args, token, reset):
     """ Authenticate to awscli using Okta """
     if version:
         print(__version__)
@@ -100,12 +98,7 @@ def main(okta_profile, profile, verbose, version,
     if not profile:
         profile = "default"
     aws_auth = AwsAuth(profile, okta_profile, verbose, logger, reset)
-    if force and profile:
-        logger.info("Force option selected, \
-            getting new credentials anyway.")
-    elif force:
-        logger.info("Force option selected, but no profile provided. \
-            Option has no effect.")
+    logger.info("Getting new credentials.")
     get_credentials(
         aws_auth, okta_profile, profile, verbose, logger, token, cache, reset
     )

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -11,14 +11,16 @@ from oktaawscli.aws_auth import AwsAuth
 
 
 def get_credentials(aws_auth, okta_profile, profile,
-                    verbose, logger, totp_token, cache):
+                    verbose, logger, totp_token, cache, reset):
     """ Gets credentials from Okta """
-    okta_auth_config = OktaAuthConfig(logger)
+    okta_auth_config = OktaAuthConfig(logger, reset)
     okta = OktaAuth(okta_profile, verbose, logger, totp_token, okta_auth_config)
 
     _, assertion = okta.get_assertion()
     role = aws_auth.choose_aws_role(assertion)
-    principal_arn, role_arn = role
+    print(role)
+    role_arn, principal_arn, _= role
+    print(role_arn)
 
     okta_auth_config.save_chosen_role_for_profile(okta_profile, role_arn)
 
@@ -60,6 +62,7 @@ def console_output(access_key_id, secret_access_key, session_token, verbose):
 @click.option('-V', '--version', is_flag=True,
               help='Outputs version number and exits')
 @click.option('-d', '--debug', is_flag=True, help='Enables debug mode')
+@click.option('-r', '--reset', is_flag=True, help='Resets default values in ~/.okta-aws')
 @click.option('-f', '--force', is_flag=True, help='Forces new STS credentials. \
 Skips STS credentials validation.')
 @click.option('--okta-profile', help="Name of the profile to use in .okta-aws. \
@@ -72,7 +75,7 @@ to ~/.okta-credentials.cache\n')
 @click.option('-t', '--token', help='TOTP token from your authenticator app')
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
 def main(okta_profile, profile, verbose, version,
-         debug, force, cache, awscli_args, token):
+         debug, force, cache, awscli_args, token, reset):
     """ Authenticate to awscli using Okta """
     if version:
         print(__version__)
@@ -103,7 +106,7 @@ def main(okta_profile, profile, verbose, version,
             logger.info("Force option selected, but no profile provided. \
                 Option has no effect.")
         get_credentials(
-            aws_auth, okta_profile, profile, verbose, logger, token, cache
+            aws_auth, okta_profile, profile, verbose, logger, token, cache, reset
         )
 
     if awscli_args:

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -9,10 +9,10 @@ from oktaawscli.okta_auth import OktaAuth
 from oktaawscli.okta_auth_config import OktaAuthConfig
 from oktaawscli.aws_auth import AwsAuth
 
+
 def get_credentials(aws_auth, okta_profile, profile,
                     verbose, logger, totp_token, cache):
     """ Gets credentials from Okta """
-
     okta_auth_config = OktaAuthConfig(logger)
     okta = OktaAuth(okta_profile, verbose, logger, totp_token, okta_auth_config)
 
@@ -66,7 +66,7 @@ Skips STS credentials validation.')
 If none is provided, then the default profile will be used.\n")
 @click.option('--profile', help="Name of the profile to store temporary \
 credentials in ~/.aws/credentials. If profile doesn't exist, it will be \
-created. If omitted, credentials will output to console.\n")
+created.\n")
 @click.option('-c', '--cache', is_flag=True, help='Cache the default profile credentials \
 to ~/.okta-credentials.cache\n')
 @click.option('-t', '--token', help='TOTP token from your authenticator app')
@@ -92,6 +92,8 @@ def main(okta_profile, profile, verbose, version,
 
     if not okta_profile:
         okta_profile = "default"
+    if not profile:
+        profile = "default"
     aws_auth = AwsAuth(profile, okta_profile, verbose, logger)
     if not aws_auth.check_sts_token(profile) or force:
         if force and profile:

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -57,6 +57,7 @@ def get_credentials(okta_profile, profile, verbose, logger,
             "\n export AWS_PROFILE=%s\n" % profile_name
         ])
         print(usage_msg)
+        exit(0)
 
 
 def console_output(access_key_id, secret_access_key, session_token, verbose):

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.2.3'
+__version__ = '0.3.0'

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ here = os.path.abspath(os.path.dirname(__file__))
 exec(open(os.path.join(here, 'oktaawscli/version.py')).read())
 
 setup(
-    name='okta-awscli',
+    name='amplify-okta-awscli',
     version=__version__,
     description='Provides a wrapper for Okta authentication to awscli',
     packages=find_packages(),
     license='Apache License 2.0',
     author='James Hale',
     author_email='james@jameshale.me',
-    url='https://github.com/jmhale/okta_awscli',
+    url='https://github.com/amplify-education/okta-awscli',
     entry_points={
         'console_scripts': [
             'okta-awscli=oktaawscli.okta_awscli:main',


### PR DESCRIPTION
* select app specified by `app` field in config if `app` field exists
* graciously reprompt for role index on bad selection
* add export flag to print creds to console
* add reset flag to reset fields in `~/.okta-aws` for current okta-profile
* store factor for default okta profiles
* add usage message when storing credentials in `/.aws/credentials`
* use system username if `username` not set in `~/.okta-aws` and no username given when prompted
* writes session token to `~/.aws/credentials` to make compatible with `boto`
* updated readme

* display account aliases when prompting for role selection
	* create a `~/.okta-alias-info` file to store account aliases
	* fetch account aliases to display in list of roles
	* cache account aliases in `~/.okta-alias-info` along with time last updated
	* refresh account alias if last updated over a week ago

* add config option `auto-write-profile` to `~/.okta-aws` 
	* if "True" and no `--profile` specified, will write aws creds to profile named for the account alias for the chosen role
		* if account alias for the chosen role is unknown, will write to `default` aws profile
	* modifies existing functionality if `--profile` specified - will write to the specified profile unless `--export` flag set
	* if `--export` flag set, will not write aws creds, will only display to console 
	* defaults to "False" to maintain existing functionality if option not set

* add config option `store-role` to `~/.okta-aws`
	* if "False", will not store role upon selection for the chosen `okta-profile`
	* Will use `role` is already defined for the chosen `okta-profile`
	* defaults to "True" to maintain existing functionality if option not set

* add config option `check-valid-creds` to `~/.okta-aws`
	* if "False", will skip making sure credentials are valid and automatically get new credentials
	* if "True", will refresh credentials only if `--profile` and `--force` are both specified
	* Defaults to True to maintain existing behavior

* cache okta session id to avoid re-authenticating with Okta when switching token
	* stores session id and expiration timestamp in `~/.okta-token`
	* if session id is expired, will re-authenticate

* add config option `session-duration` to `~/.okta-aws`
	* takes in session duration in seconds
	* to be valid, must be between 3600 and 43200 (1 hour to 12 hours)
	* if invalid or not specified, defaults to 3600 (1 hour)

* add config option `region` to `~/.okta-aws`
	* specifies the region to access resources in
	* defaults to `us-east-1`