### PR TITLE
Datetime fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.3.2] 2018-08-31
+### Changed:
+- Fix datetime parsing of expiration date for Okta token
+
 ## [0.3.1] 2018-08-23
 ### Changed:
 - Better error handling for selection of roles

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -209,10 +209,10 @@ class OktaAuth():
         if session_info.get('expiration_date'):
             expiration_date = datetime.strptime(
                 session_info.get('expiration_date'),
-                '%Y-%m-%dT%H:%M:%S.000Z'
+                '%Y-%m-%dT%H:%M:%S.%fZ'
             )
 
-        current_time = datetime.now()
+        current_time = datetime.utcnow()
         if max([current_time, expiration_date]) == expiration_date:
             self.logger.info("Using cached Okta session id from ~/.okta-token")
             return session_info.get('session_id')

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.3.1'
+__version__ = '0.3.2'


### PR DESCRIPTION
Fix issue where the expiration date (UTC) would be compared to current time (Local), resulting in invalid session tokens being treated as valid.