### PR TITLE
Fix STS Token Exception Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.3.4] 2018-09-18
+### Changed:
+- Fixed exception handling of missing credentials exception for Python 3
+
 ## [0.3.3] 2018-09-12
 ### Added:
 - Add parameter `-a, --account` to okta-awscli

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -119,7 +119,7 @@ of roles assigned to you.""" % self.role)
             sts.get_caller_identity()
 
         except (ClientError, NoCredentialsError) as ex:
-            if ex.fmt == 'Unable to locate credentials':
+            if str(ex) == 'Unable to locate credentials':
                 self.logger.info(
                     "No credentials have been located. Requesting new credentials.")
                 return False

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -119,7 +119,7 @@ of roles assigned to you.""" % self.role)
             sts.get_caller_identity()
 
         except (ClientError, NoCredentialsError) as ex:
-            if ex[0] == 'Unable to locate credentials':
+            if ex.fmt == 'Unable to locate credentials':
                 self.logger.info(
                     "No credentials have been located. Requesting new credentials.")
                 return False

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.3.3'
+__version__ = '0.3.4'


### PR DESCRIPTION
Looks like when I added the second possible exception that it breaks in Python 3 stating the object is not indexable when credentials expire. Comparing the exception casted as a string seems to work in both exceptions thrown in both Python 2 & Python 3 while I was testing.