### PR TITLE
Catch Exception When Assuming Role for Alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.3.5] 2018-09-28
+### Changed
+- Fixed exception that would break program when OKTA was configured with accounts that did not give OKTA permissions to login
+
 ## [0.3.4] 2018-09-18
 ### Changed:
 - Fixed exception handling of missing credentials exception for Python 3

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -14,7 +14,7 @@ import six
 class AwsAuth():
     """ Methods to support AWS authentication using STS """
 
-    def __init__(self, profile, okta_profile, account, verbose, logger, region, reset):
+    def __init__(self, profile, okta_profile, account, verbose, logger, region, reset, debug=False):
         home_dir = os.path.expanduser('~')
         self.creds_dir = os.path.join(home_dir, ".aws")
         self.creds_file = os.path.join(self.creds_dir, "credentials")
@@ -24,6 +24,7 @@ class AwsAuth():
         self.logger = logger
         self.role = ""
         self.region = region
+        self.debug = debug
 
         okta_info = os.path.join(home_dir, '.okta-alias-info')
         if not os.path.isfile(okta_info):
@@ -273,10 +274,10 @@ of roles assigned to you.""" % self.role)
                 SAMLAssertion=assertion
             )
         except ClientError as ex:
-            self.logger.info(
+            self.logger.warning(
                 "Unable to assume role '%s', cannot get account alias",
                 role_arn,
-                exc_info=True
+                exc_info=self.debug
             )
             return None
 
@@ -293,7 +294,10 @@ of roles assigned to you.""" % self.role)
         except ClientError as ex:
             if ex.response['Error']['Code'] == 'AccessDenied':
                 self.logger.info(
-                    'Role %s not authorized to perform `list_account_aliases`.', role_arn)
+                    'Role %s not authorized to perform `list_account_aliases`.',
+                    role_arn,
+                    exc_info=self.debug
+                )
             return "unknown"
 
     @staticmethod

--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -231,6 +231,8 @@ of roles assigned to you.""" % self.role)
                 self.logger.info("Refreshing cached alias for role %s" % role.role_arn)
                 alias = self.__get_account_alias(role.role_arn, role.principal_arn, assertion)
                 last_updated = current_date
+                if alias is None:
+                    continue
 
             self.logger.info("Using cached alias for role %s" % role.role_arn)
             role_info.append(
@@ -255,13 +257,29 @@ of roles assigned to you.""" % self.role)
         return role_info
 
     def __get_account_alias(self, role_arn, principal_arn, assertion):
-        """ Gets account alias for given role """
+        """
+        Gets account alias for given role
+        :param role_arn: The ARN of the role.
+        :param principal_arn: The ARN of the principle.
+        :param assertion: The SAML assertion.
+        :return: The alias of the account that this role is in. "Unknown" is returned if the role does not
+        have access to the account's alias. None is returned if the role cannot be assumed.
+        """
         sts = boto3.client('sts')
-        saml_resp = sts.assume_role_with_saml(
-            RoleArn=role_arn,
-            PrincipalArn=principal_arn,
-            SAMLAssertion=assertion
-        )
+        try:
+            saml_resp = sts.assume_role_with_saml(
+                RoleArn=role_arn,
+                PrincipalArn=principal_arn,
+                SAMLAssertion=assertion
+            )
+        except ClientError as ex:
+            self.logger.info(
+                "Unable to assume role '%s', cannot get account alias",
+                role_arn,
+                exc_info=True
+            )
+            return None
+
         iam = boto3.client(
             'iam',
             aws_access_key_id=saml_resp['Credentials']['AccessKeyId'],
@@ -275,7 +293,7 @@ of roles assigned to you.""" % self.role)
         except ClientError as ex:
             if ex.response['Error']['Code'] == 'AccessDenied':
                 self.logger.info(
-                    'Role %s not authorized to perform `list_account_aliases`.' % role_arn)
+                    'Role %s not authorized to perform `list_account_aliases`.', role_arn)
             return "unknown"
 
     @staticmethod

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -17,7 +17,7 @@ except NameError:
 class OktaAuth():
     """ Handles auth to Okta and returns SAML assertion """
     def __init__(self, okta_profile, verbose, logger,
-                 totp_token, okta_auth_config):
+                 totp_token, okta_auth_config, debug=False):
         self.okta_profile = okta_profile
         self.totp_token = totp_token
         self.logger = logger
@@ -27,6 +27,7 @@ class OktaAuth():
         self.https_base_url = "https://%s" % okta_auth_config.base_url_for(okta_profile)
         self.factor = okta_auth_config.factor_for(okta_profile)
         self.app = okta_auth_config.app_for(okta_profile)
+        self.debug = debug
 
         okta_info = os.path.join(os.path.expanduser('~'), '.okta-token')
         if not os.path.isfile(okta_info):

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -10,12 +10,12 @@ from oktaawscli.okta_auth_config import OktaAuthConfig
 from oktaawscli.aws_auth import AwsAuth
 
 def get_credentials(okta_profile, profile, account, write_default, verbose, logger,
-                    totp_token, cache, export, reset, force):
+                    totp_token, cache, export, reset, force, debug=False):
     """ Gets credentials from Okta """
     okta_auth_config = OktaAuthConfig(logger, reset)
 
     region = okta_auth_config.region_for(okta_profile)
-    aws_auth = AwsAuth(profile, okta_profile, account, verbose, logger, region, reset)
+    aws_auth = AwsAuth(profile, okta_profile, account, verbose, logger, region, reset, debug=debug)
 
     check_creds = okta_auth_config.get_check_valid_creds(okta_profile)
     if not force and not export and check_creds and aws_auth.check_sts_token(profile):
@@ -25,7 +25,7 @@ def get_credentials(okta_profile, profile, account, write_default, verbose, logg
         exit(0)
 
     okta = OktaAuth(okta_profile, verbose, logger,
-                    totp_token, okta_auth_config)
+                    totp_token, okta_auth_config, debug=debug)
 
     _, assertion = okta.get_assertion()
     role = aws_auth.choose_aws_role(assertion)
@@ -136,7 +136,7 @@ def main(okta_profile, profile, verbose, version, write_default,
         okta_profile = account
     get_credentials(
         okta_profile, profile, account, write_default, verbose, logger,
-        token, cache, export, reset, force
+        token, cache, export, reset, force, debug=debug
     )
 
     if awscli_args:

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.3.4'
+__version__ = '0.3.5'


### PR DESCRIPTION
It's possible that an account might be added to OKTA but permissions
might be mangled such that the roles in the account cannot be assumed
yet. Rather than throw an exception and block folks from assuming all
roles, let's hide roles that cannot be assumed, with optional logging to
let people dive a bit deeper.

Now, if we try to get the account alias and cannot assume the role, we
return None. And if the account alias function returns None, we hide
that role from the list of roles to assume by skipping it.

okta-awscli will continue to attempt to assume the role every time they
run the command, so as soon as the permissions are fixed, the role will
appear in the list.