### PR TITLE
Fix Region Lookup Bug

### DIFF
--- a/oktaawscli/aws_auth.py
+++ b/oktaawscli/aws_auth.py
@@ -133,12 +133,9 @@ of roles assigned to you.""" % self.role)
         self.logger.info("STS credentials are valid. Nothing to do.")
         return True
 
-    def write_sts_token(self, profile, access_key_id, secret_access_key, session_token, region_override=None):
+    def write_sts_token(self, profile, access_key_id, secret_access_key, session_token, region=None):
         """ Writes STS auth information to credentials file """
-        if region_override is not None:
-          region = region_override
-        else:
-          region = self.region
+        region = region or self.region
         output = 'json'
         if not os.path.exists(self.creds_dir):
             os.makedirs(self.creds_dir)

--- a/oktaawscli/okta_auth_config.py
+++ b/oktaawscli/okta_auth_config.py
@@ -76,10 +76,10 @@ class OktaAuthConfig():
         self.logger.debug("Setting app to %s" % app)
         return app
 
-    def region_for(self, okta_profile):
+    def region_for(self, okta_profile, default="us-east-1"):
         """ Gets region from config """
-        region = self._value.get(okta_profile, 'region', fallback="us-east-1")
-        self.logger.debug("Setting region to %s" % region)
+        region = self._value.get(okta_profile, 'region', fallback=default)
+        self.logger.debug("Setting region=%s from section=%s", region, okta_profile)
         return region
 
     def get_check_valid_creds(self, okta_profile):

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -62,12 +62,22 @@ def get_credentials(okta_profile, profile, account, write_default, verbose, logg
         # Check okta config again for region, but now with manually chosen account alias
         region = okta_auth_config.region_for(profile_name)
         logger.info("Export flag not set, will write credentials to ~/.aws/credentials.")
-        aws_auth.write_sts_token(profile_name, access_key_id,
-                                 secret_access_key, session_token, region)
+        aws_auth.write_sts_token(
+            profile=profile_name,
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            session_token=session_token,
+            region=region,
+        )
         if write_default:
             print("Writing to default AWS profile")
-            aws_auth.write_sts_token('default', access_key_id,
-                                     secret_access_key, session_token, region)
+            aws_auth.write_sts_token(
+                profile='default',
+                access_key_id=access_key_id,
+                secret_access_key=secret_access_key,
+                session_token=session_token,
+                region=region,
+            )
         # Only print usage message if account argument wasn't specified
         elif account is None:
             usage_msg = "".join([

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -59,8 +59,6 @@ def get_credentials(okta_profile, profile, account, write_default, verbose, logg
             cache.close()
         exit(0)
     else:
-        # Check okta config again for region, but now with manually chosen account alias
-        region = okta_auth_config.region_for(profile_name)
         logger.info("Export flag not set, will write credentials to ~/.aws/credentials.")
         aws_auth.write_sts_token(
             profile=profile_name,

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -11,11 +11,11 @@ from oktaawscli.aws_auth import AwsAuth
 
 
 def get_credentials(okta_profile, profile, account, write_default, verbose, logger,
-                    totp_token, cache, export, reset, force, debug=False):
+                    totp_token, cache, export, reset, force, region, debug=False):
     """ Gets credentials from Okta """
     okta_auth_config = OktaAuthConfig(logger, reset)
 
-    region = okta_auth_config.region_for(okta_profile)
+    region = region or okta_auth_config.region_for(okta_profile)
     aws_auth = AwsAuth(profile, okta_profile, account, verbose, logger, region, reset, debug=debug)
 
     check_creds = okta_auth_config.get_check_valid_creds(okta_profile)
@@ -122,9 +122,10 @@ to ~/.okta-credentials.cache\n')
 @click.option('-t', '--token', help='TOTP token from your authenticator app')
 @click.option('-a', '--account', help='Target account to authenticate to. \
 Also writes AWS credentials to default profile ')
+@click.option('-r', '--region', help='The AWS region to export credentials for')
 @click.argument('awscli_args', nargs=-1, type=click.UNPROCESSED)
 def main(okta_profile, profile, verbose, version, write_default,
-         debug, force, export, cache, awscli_args, token, reset, account):
+         debug, force, export, cache, awscli_args, token, reset, account, region):
     """ Authenticate to awscli using Okta """
     if version:
         print(__version__)
@@ -147,9 +148,11 @@ def main(okta_profile, profile, verbose, version, write_default,
     if account:
         profile = account
         okta_profile = account
+    if region:
+        logger.debug("Overwriting region to be %s", region)
     get_credentials(
         okta_profile, profile, account, write_default, verbose, logger,
-        token, cache, export, reset, force, debug=debug
+        token, cache, export, reset, force, region, debug=debug
     )
 
     if awscli_args:

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -9,6 +9,7 @@ from oktaawscli.okta_auth import OktaAuth
 from oktaawscli.okta_auth_config import OktaAuthConfig
 from oktaawscli.aws_auth import AwsAuth
 
+
 def get_credentials(okta_profile, profile, account, write_default, verbose, logger,
                     totp_token, cache, export, reset, force, debug=False):
     """ Gets credentials from Okta """
@@ -75,6 +76,7 @@ def get_credentials(okta_profile, profile, account, write_default, verbose, logg
             ])
             print(usage_msg)
         exit(0)
+
 
 def console_output(access_key_id, secret_access_key, session_token, verbose):
     """ Outputs STS credentials to console """
@@ -146,6 +148,7 @@ def main(okta_profile, profile, verbose, version, write_default,
         cmdline = ['aws', '--profile', profile] + list(awscli_args)
         logger.info('Invoking: %s', ' '.join(cmdline))
         call(cmdline)
+
 
 if __name__ == "__main__":
     # pylint: disable=E1120

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = '0.4.0'
+__version__ = '0.4.3'


### PR DESCRIPTION
We should not lookup the region against based on the aws-profile name. There is no guarantee that this profile exists and it means that we ignore the region set in the okta-profile. It's also very confusing behavior.

Also refactored the command's handling of region a little bit as well.