### PR TITLE
Bigfix: Remove duplicate -r flag

### DIFF
--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -166,7 +166,7 @@ def console_output(access_key_id, secret_access_key, session_token, verbose):
 Skips STS credentials validation.",
 )
 @click.option(
-    "-r", "--reset", is_flag=True, help="Resets default values in ~/.okta-aws"
+    "--reset", is_flag=True, help="Resets default values in ~/.okta-aws"
 )
 @click.option(
     "-e",

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = "0.4.8"
+__version__ = "0.4.9"


### PR DESCRIPTION
Found this issue while packaging executable for brew distribution. In okta_awscli.main(), the click config sets two different parameter options with shorthand `-r` (`--region` and `--reset`). This removes the shorthand option for `--reset`, in order to suppress this warning:


```bash
UserWarning: The parameter -r is used more than once. Remove its duplicate as parameters should be unique.
  parser = self.make_parser(ctx)
UserWarning: The parameter -r is used more than once. Remove its duplicate as parameters should be unique.
  self.parse_args(ctx, args)
```