### PR TITLE
[AT-14117] catch okta error

### DIFF
--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -249,7 +249,7 @@ class OktaAuth:
                            "try again: ~/.cache, ~/.aws/credentials, and ~/.okta-token")
                 self.logger.error(message)
                 print(message)
-                raise e
+                sys.exit(1)
         resp = raw_resp.json()
         aws_apps = []
         for app in resp:

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -245,7 +245,8 @@ class OktaAuth:
             raw_resp.raise_for_status()
         except HTTPError as e:
             if raw_resp.status_code == 403 and "Invalid session" in raw_resp.text:
-                message = "Okta session revoked. Please delete the following files and try again: ~/.cache, ~/.aws/credentials, and ~/.okta-token"
+                message = ("Okta session revoked. Please delete the following files and "
+                           "try again: ~/.cache, ~/.aws/credentials, and ~/.okta-token")
                 self.logger.error(message)
                 print(message)
                 raise e

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -241,14 +241,12 @@ class OktaAuth:
             raw_resp = requests.get(
                 self.https_base_url + "/api/v1/users/me/appLinks", headers=headers
             )
-            print(raw_resp.text) # DEBUG!
             raw_resp.raise_for_status()
         except HTTPError as e:
             if raw_resp.status_code == 403 and "Invalid session" in raw_resp.text:
                 message = ("Okta session revoked. Please delete the following files and "
                            "try again: ~/.cache, ~/.aws/credentials, and ~/.okta-token")
                 self.logger.error(message)
-                print(message)
                 sys.exit(1)
         resp = raw_resp.json()
         aws_apps = []

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -244,7 +244,7 @@ class OktaAuth:
             raw_resp.raise_for_status()
         except HTTPError as e:
             if raw_resp.status_code == 403 and "Invalid session" in raw_resp.text:
-                message = ("Okta session revoked. Please delete the following files and "
+                message = ("Okta session invalidated. Please delete the following files and "
                            "try again: ~/.cache, ~/.aws/credentials, and ~/.okta-token")
                 self.logger.error(message)
                 sys.exit(1)

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -239,6 +239,7 @@ class OktaAuth:
         resp = requests.get(
             self.https_base_url + "/api/v1/users/me/appLinks", headers=headers
         ).json()
+        print(resp)
         aws_apps = []
         for app in resp:
             if app["appName"] == "amazon_aws":


### PR DESCRIPTION
This PR addresses [AT-14117], which was created in response to an error I encountered while trying to use okta-awscli last week:`TypeError: string indices must be integers, not 'str'`. After investigating the code, @skim-amplify and I discovered that okta-awscli still thought I was logged in (based on the contents of the local credential files) despite the session being revoked remotely. As a result, Okta's API returned an error message that went uncaught instead of a list of apps the user has access to. I added try-except that catches HTTPErrors raised by raise_for_status, and logs a message instructing the user how to resolve this error if the error message contains "Invalid session".