### PR TITLE
[AT-14212] Auto-fetch new token

### DIFF
--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -6,7 +6,6 @@ import time
 import json
 from datetime import datetime
 import requests
-from requests.exceptions import HTTPError
 
 from bs4 import BeautifulSoup as bs
 
@@ -235,15 +234,12 @@ class OktaAuth:
 
     def get_apps(self, session_id):
         """Gets apps for the user"""
-        try:
-            sid = "sid=%s" % session_id
-            headers = {"Cookie": sid}
-            raw_resp = requests.get(
-                self.https_base_url + "/api/v1/users/me/appLinks", headers=headers
-            )
-            raw_resp.raise_for_status()
-        except HTTPError as e:
-            raise e
+        sid = "sid=%s" % session_id
+        headers = {"Cookie": sid}
+        raw_resp = requests.get(
+            self.https_base_url + "/api/v1/users/me/appLinks", headers=headers
+        )
+        raw_resp.raise_for_status()
 
         resp = raw_resp.json()
         aws_apps = []
@@ -289,13 +285,7 @@ class OktaAuth:
     def get_assertion(self):
         """Main method to get SAML assertion from Okta"""
         session_id = self.primary_auth()
-        try:
-            app_name, app_link = self.get_apps(session_id)
-        except HTTPError as e:
-            if e.response is not None and e.response.status_code == 403 and "Invalid session" in e.response.text:
-                message = "Okta session invalidated. Refreshing token now..."
-                self.logger.error(message)
-                os.system("rm -rf ~/.okta-token")
+        app_name, app_link = self.get_apps(session_id)
         sid = "sid=%s" % session_id
         headers = {"Cookie": sid}
         resp = requests.get(app_link, headers=headers)

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -256,12 +256,10 @@ class OktaAuth:
         """Gets apps for the user"""
         sid = "sid=%s" % session_id
         headers = {"Cookie": sid}
-        raw_resp = requests.get(
+        resp = requests.get(
             self.https_base_url + "/api/v1/users/me/appLinks", headers=headers
-        )
-        raw_resp.raise_for_status()
+        ).json()
 
-        resp = raw_resp.json()
         aws_apps = []
         for app in resp:
             if app["appName"] == "amazon_aws":

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -50,7 +50,7 @@ class OktaAuth:
             "username": self.okta_auth_config.username_for(self.okta_profile),
             "password": self.okta_auth_config.password_for(self.okta_profile),
         }
-        # insert action-packed documentation link here!
+        # https://developer.okta.com/docs/reference/api/authn/
         resp = requests.post(self.https_base_url + "/api/v1/authn", json=auth_data)
         resp_json = resp.json()
         if "status" in resp_json:
@@ -193,7 +193,7 @@ class OktaAuth:
     def get_session(self, session_token):
         """Gets a session cookie from a session token"""
         data = {"sessionToken": session_token}
-        # insert action-packed documentation link here!
+        # https://developer.okta.com/docs/guides/ie-limitations/main/#sessions-apis
         resp = requests.post(self.https_base_url + "/api/v1/sessions", json=data).json()
         self.cache_session_id(resp["id"], resp["expiresAt"])
         return resp["id"]
@@ -243,7 +243,7 @@ class OktaAuth:
         try:
             sid = "sid=%s" % session_id
             headers = {"Cookie": sid}
-            # insert action-packed documentation link here!
+            # https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/getUser
             raw_resp = requests.get(
                 self.https_base_url + "/api/v1/users/me", headers=headers
             )
@@ -261,7 +261,7 @@ class OktaAuth:
         """Gets apps for the user"""
         sid = "sid=%s" % session_id
         headers = {"Cookie": sid}
-        # insert action-packed documentation link here!
+        # https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserResources/#tag/UserResources/operation/listAppLinks
         resp = requests.get(
             self.https_base_url + "/api/v1/users/me/appLinks", headers=headers
         ).json()

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -247,6 +247,7 @@ class OktaAuth:
                 message = "Okta session invalidated. Refreshing token now..."
                 self.logger.error(message)
                 os.system("rm -rf ~/.okta-token")
+                sys.exit(1)
             else:
                 raise e
 

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -48,6 +48,7 @@ class OktaAuth:
             "username": self.okta_auth_config.username_for(self.okta_profile),
             "password": self.okta_auth_config.password_for(self.okta_profile),
         }
+        # insert action-packed documentation link here!
         resp = requests.post(self.https_base_url + "/api/v1/authn", json=auth_data)
         resp_json = resp.json()
         if "status" in resp_json:
@@ -190,6 +191,7 @@ class OktaAuth:
     def get_session(self, session_token):
         """Gets a session cookie from a session token"""
         data = {"sessionToken": session_token}
+        # insert action-packed documentation link here!
         resp = requests.post(self.https_base_url + "/api/v1/sessions", json=data).json()
         self.cache_session_id(resp["id"], resp["expiresAt"])
         return resp["id"]
@@ -239,6 +241,7 @@ class OktaAuth:
         try:
             sid = "sid=%s" % session_id
             headers = {"Cookie": sid}
+            # insert action-packed documentation link here!
             raw_resp = requests.get(
                 self.https_base_url + "/api/v1/users/me", headers=headers
             )
@@ -256,6 +259,7 @@ class OktaAuth:
         """Gets apps for the user"""
         sid = "sid=%s" % session_id
         headers = {"Cookie": sid}
+        # insert action-packed documentation link here!
         resp = requests.get(
             self.https_base_url + "/api/v1/users/me/appLinks", headers=headers
         ).json()

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -244,9 +244,9 @@ class OktaAuth:
             raw_resp.raise_for_status()
         except HTTPError as e:
             if e.response is not None and e.response.status_code == 403 and "Invalid session" in e.response.text:
-                message = "Okta session invalidated. Please delete ~/.okta-token and try again."
+                message = "Okta session invalidated. Refreshing token now..."
                 self.logger.error(message)
-                sys.exit(1)
+                os.system("rm -rf ~/.okta-token")
             else:
                 raise e
 

--- a/oktaawscli/okta_auth.py
+++ b/oktaawscli/okta_auth.py
@@ -44,6 +44,8 @@ class OktaAuth:
             # if there's no remote-local desync, return the cached token
             if self.check_for_desync(session_id) is False:
                 return session_id
+            else:
+                self.logger.warning("Current Okta session was invalidated. Refreshing token now...")
         auth_data = {
             "username": self.okta_auth_config.username_for(self.okta_profile),
             "password": self.okta_auth_config.password_for(self.okta_profile),

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -57,7 +57,7 @@ def get_credentials(
         if e.response is not None and e.response.status_code == 403 and "Invalid session" in e.response.text:
             message = "Okta session invalidated. Refreshing token now..."
             logger.error(message)
-            os.system("rm -rf ~/.okta-token")
+            os.system("rm ~/.okta-token")
             okta = OktaAuth(
                 okta_profile, verbose, logger, totp_token, okta_auth_config, debug=debug
             )

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -9,9 +9,6 @@ from oktaawscli.okta_auth import OktaAuth
 from oktaawscli.okta_auth_config import OktaAuthConfig
 from oktaawscli.aws_auth import AwsAuth
 
-from requests.exceptions import HTTPError
-
-
 def get_credentials(
     okta_profile,
     profile,
@@ -48,22 +45,10 @@ def get_credentials(
             print("Copying AWS profile creds to default")
         exit(0)
 
-    try:
-        okta = OktaAuth(
-            okta_profile, verbose, logger, totp_token, okta_auth_config, debug=debug
-        )
-        _, assertion = okta.get_assertion()
-    except HTTPError as e:
-        if e.response is None or e.response.status_code != 403 or "Invalid session" not in e.response.text:
-            raise e
-        message = "Okta session invalidated. Refreshing token now..."
-        logger.error(message)
-        os.system("rm ~/.okta-token")
-        okta = OktaAuth(
-            okta_profile, verbose, logger, totp_token, okta_auth_config, debug=debug
-        )
-        _, assertion = okta.get_assertion()
-
+    okta = OktaAuth(
+        okta_profile, verbose, logger, totp_token, okta_auth_config, debug=debug
+    )
+    _, assertion = okta.get_assertion()
     role = aws_auth.choose_aws_role(assertion)
     role_arn, principal_arn, alias = role
 

--- a/oktaawscli/okta_awscli.py
+++ b/oktaawscli/okta_awscli.py
@@ -54,16 +54,15 @@ def get_credentials(
         )
         _, assertion = okta.get_assertion()
     except HTTPError as e:
-        if e.response is not None and e.response.status_code == 403 and "Invalid session" in e.response.text:
-            message = "Okta session invalidated. Refreshing token now..."
-            logger.error(message)
-            os.system("rm ~/.okta-token")
-            okta = OktaAuth(
-                okta_profile, verbose, logger, totp_token, okta_auth_config, debug=debug
-            )
-            _, assertion = okta.get_assertion()
-        else:
+        if e.response is None or e.response.status_code != 403 or "Invalid session" not in e.response.text:
             raise e
+        message = "Okta session invalidated. Refreshing token now..."
+        logger.error(message)
+        os.system("rm ~/.okta-token")
+        okta = OktaAuth(
+            okta_profile, verbose, logger, totp_token, okta_auth_config, debug=debug
+        )
+        _, assertion = okta.get_assertion()
 
     role = aws_auth.choose_aws_role(assertion)
     role_arn, principal_arn, alias = role

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = "0.4.11"
+__version__ = "0.4.12"


### PR DESCRIPTION
This PR addresses [AT-14212] by checking whether an error indicative of a token desync occurred while calling get_assertion. If so, we log an error message, delete the file where the old credentials were, recreate the OktaAuth object (therefore recreating the file), and run get_assertion again. Here's what the output looks like when handling the error:

<img width="470" height="104" alt="image" src="https://github.com/user-attachments/assets/3f860f49-093b-4cbb-82d0-c878868536a8" />


[AT-14212]: https://amplify-education.atlassian.net/browse/AT-14212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ