### PR TITLE
Release 0.4.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.14] 2026-05-13
+### Changed
+- Version bump only. Republish of 0.4.13 — the 0.4.13 deploy build failed with HTTP 409 from CodeArtifact because that version had already been published from an earlier in-PR build.
+
 ## [0.4.13] 2026-05-11
 ### Changed
 - Cross-process file locking and atomic-rename writes for `~/.aws/credentials`, `~/.okta-aws`, and `~/.okta-alias-info`. Multiple `okta-awscli` processes can now run in parallel against the same dotfiles without clobbering each other.

--- a/oktaawscli/version.py
+++ b/oktaawscli/version.py
@@ -1,2 +1,2 @@
 """ version string """
-__version__ = "0.4.13"
+__version__ = "0.4.14"


### PR DESCRIPTION
## Summary

Bumps `__version__` to `0.4.14` so the deploy CodeBuild can publish to CodeArtifact again. 0.4.13 was already uploaded by an earlier in-PR run of the deploy build (before [terraform-config#36522](https://github.com/amplify-education/terraform-config/pull/36522) restricted the trigger to main), so the post-merge run of #29 hit HTTP 409:

```
ERROR HTTPError: 409 Conflict from https://amplify-023225265359.d.codeartifact.us-west-2.amazonaws.com/pypi/amplify-okta-awscli/0.4.13/...
```

No code changes — pure republish of the 0.4.13 functionality under a new version number.

## Test plan

- [ ] CodeBuild `okta-awscli-deploy` run on this merge succeeds and `aws codeartifact list-package-versions ... --package amplify-okta-awscli` shows `0.4.14` Published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)